### PR TITLE
Add insecure option to allow client not verify certs

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ var (
 	path       = flag.String("path", "/", "URL path for websocket.")
 	host       = flag.String("host", "cloudfront.com", "Hostname for server.")
 	tlsEnabled = flag.Bool("tls", false, "Enable TLS.")
+	inSecure   = flag.Bool("insecure", false, "(client) Allow insecure TLS connection, without verifing certs.")
 	cert       = flag.String("cert", "", "Path to TLS certificate file. Overrides certRaw. Default: ~/.acme.sh/{host}/fullchain.cer")
 	certRaw    = flag.String("certRaw", "", "Raw TLS certificate content. Intended only for Android.")
 	key        = flag.String("key", "", "(server) Path to TLS key file. Default: ~/.acme.sh/{host}/{host}.key")
@@ -168,12 +169,16 @@ func generateConfig() (*core.Config, error) {
 			}
 			tlsConfig.Certificate = []*tls.Certificate{&certificate}
 		} else if *cert != "" || *certRaw != "" {
+			// client verify with certs
 			certificate := tls.Certificate{Usage: tls.Certificate_AUTHORITY_VERIFY}
 			certificate.Certificate, err = readCertificate()
 			if err != nil {
 				return nil, newError("failed to read cert").Base(err)
 			}
 			tlsConfig.Certificate = []*tls.Certificate{&certificate}
+		} else if *inSecure {
+			// client not verify at all
+			tlsConfig.AllowInsecure = true
 		}
 		streamConfig.SecurityType = serial.GetMessageType(&tlsConfig)
 		streamConfig.SecuritySettings = []*serial.TypedMessage{serial.ToTypedMessage(&tlsConfig)}
@@ -255,6 +260,9 @@ func startV2Ray() (core.Server, error) {
 		}
 		if _, b := opts.Get("tls"); b {
 			*tlsEnabled = true
+		}
+		if _, b := opts.Get("insecure"); b {
+			*inSecure = true
 		}
 		if c, b := opts.Get("host"); b {
 			*host = c


### PR DESCRIPTION
The same "AllowInsecure" option is present in v2ray config ( https://www.v2ray.com/chapter_02/05_transport.html#tlsobject )

It's useful when client prefer using different address to the server, ie. raw ip / ipv6 ip, or fake the destination by assigning stub host, fake SNI  to hide from the sniffing of traffic logs from ISP (eg unicom 4G network records).

It DOES decrese security of transportation, but offer more probability for users to choose from. The option named "insecure" to warn about insecurity and defaultly remain false.