### PR TITLE
completely disable multiplexing when mux is set to 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,9 @@ func generateConfig() (*core.Config, error) {
 				{Key: "Host", Value: *host},
 			},
 		}
-		connectionReuse = true
+		if *mux != 0 {
+			connectionReuse = true
+		}
 	case "quic":
 		transportSettings = &quic.Config{
 			Security: &protocol.SecurityConfig{Type: protocol.SecurityType_NONE},


### PR DESCRIPTION
Some people use v2ray as server and ss+plugin as client or vice versa.

In those cases v2ray needs to be configured in a very complex way, [here](https://gist.github.com/lcdtyph/2ad6d9b9779a6c489347677dfbb236d4) is an example.
This is because v2ray and ss+plugin have different protocol model:

| ss+plugin | v2ray |
| --- | --- |
| ss->mux->ws | mux->ss->ws|

If we disable mux completely, both the protocols are same, and easy to configure.
Also the iOS app (Quantumult X) supports the v2ray protocol model, disabling mux makes
it possible to use ss+plugin as its server side.

I hope this pr could simplify the configuration in those cases.