### PR TITLE
Fix passing self signed cert via arg/env

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,10 @@ func readCertificate() ([]byte, error) {
 		return filesystem.ReadFile(*cert)
 	}
 	if *certRaw != "" {
-		return []byte(*certRaw), nil
+		certHead := "-----BEGIN CERTIFICATE-----"
+		certTail := "-----END CERTIFICATE-----"
+		fixedCert := certHead + "\n" + (*certRaw)[len(certHead):len(*certRaw)-len(certTail)] + "\n" + certTail
+		return []byte(fixedCert), nil
 	}
 	panic("thou shalt not reach hear")
 }


### PR DESCRIPTION
We cannot pass standard x509 cert, which includes at least two EOLs, via argument/env.

This patch fixes the issue with self signed certificates on Android and other clients.