### PR TITLE
Add support for gRPC protocol

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/v2fly/v2ray-core/v4/proxy/dokodemo"
 	"github.com/v2fly/v2ray-core/v4/proxy/freedom"
 	"github.com/v2fly/v2ray-core/v4/transport/internet"
+	"github.com/v2fly/v2ray-core/v4/transport/internet/grpc"
 	"github.com/v2fly/v2ray-core/v4/transport/internet/quic"
 	"github.com/v2fly/v2ray-core/v4/transport/internet/tls"
 	"github.com/v2fly/v2ray-core/v4/transport/internet/websocket"
@@ -37,24 +38,25 @@ import (
 var (
 	VERSION = "custom"
 
-	vpn        = flag.Bool("V", false, "Run in VPN mode.")
-	fastOpen   = flag.Bool("fast-open", false, "Enable TCP fast open.")
-	localAddr  = flag.String("localAddr", "127.0.0.1", "local address to listen on.")
-	localPort  = flag.String("localPort", "1984", "local port to listen on.")
-	remoteAddr = flag.String("remoteAddr", "127.0.0.1", "remote address to forward.")
-	remotePort = flag.String("remotePort", "1080", "remote port to forward.")
-	path       = flag.String("path", "/", "URL path for websocket.")
-	host       = flag.String("host", "cloudfront.com", "Hostname for server.")
-	tlsEnabled = flag.Bool("tls", false, "Enable TLS.")
-	cert       = flag.String("cert", "", "Path to TLS certificate file. Overrides certRaw. Default: ~/.acme.sh/{host}/fullchain.cer")
-	certRaw    = flag.String("certRaw", "", "Raw TLS certificate content. Intended only for Android.")
-	key        = flag.String("key", "", "(server) Path to TLS key file. Default: ~/.acme.sh/{host}/{host}.key")
-	mode       = flag.String("mode", "websocket", "Transport mode: websocket, quic (enforced tls).")
-	mux        = flag.Int("mux", 1, "Concurrent multiplexed connections (websocket client mode only).")
-	server     = flag.Bool("server", false, "Run in server mode")
-	logLevel   = flag.String("loglevel", "", "loglevel for v2ray: debug, info, warning (default), error, none.")
-	version    = flag.Bool("version", false, "Show current version of v2ray-plugin")
-	fwmark     = flag.Int("fwmark", 0, "Set SO_MARK option for outbound sockets.")
+	vpn         = flag.Bool("V", false, "Run in VPN mode.")
+	fastOpen    = flag.Bool("fast-open", false, "Enable TCP fast open.")
+	localAddr   = flag.String("localAddr", "127.0.0.1", "local address to listen on.")
+	localPort   = flag.String("localPort", "1984", "local port to listen on.")
+	remoteAddr  = flag.String("remoteAddr", "127.0.0.1", "remote address to forward.")
+	remotePort  = flag.String("remotePort", "1080", "remote port to forward.")
+	path        = flag.String("path", "/", "URL path for websocket.")
+	serviceName = flag.String("serviceName", "GunService", "Service name for grpc.")
+	host        = flag.String("host", "cloudfront.com", "Hostname for server.")
+	tlsEnabled  = flag.Bool("tls", false, "Enable TLS.")
+	cert        = flag.String("cert", "", "Path to TLS certificate file. Overrides certRaw. Default: ~/.acme.sh/{host}/fullchain.cer")
+	certRaw     = flag.String("certRaw", "", "Raw TLS certificate content. Intended only for Android.")
+	key         = flag.String("key", "", "(server) Path to TLS key file. Default: ~/.acme.sh/{host}/{host}.key")
+	mode        = flag.String("mode", "websocket", "Transport mode: websocket, quic (enforced tls), grpc.")
+	mux         = flag.Int("mux", 1, "Concurrent multiplexed connections (websocket client mode only).")
+	server      = flag.Bool("server", false, "Run in server mode")
+	logLevel    = flag.String("loglevel", "", "loglevel for v2ray: debug, info, warning (default), error, none.")
+	version     = flag.Bool("version", false, "Show current version of v2ray-plugin")
+	fwmark      = flag.Int("fwmark", 0, "Set SO_MARK option for outbound sockets.")
 )
 
 func homeDir() string {
@@ -140,6 +142,10 @@ func generateConfig() (*core.Config, error) {
 			Security: &protocol.SecurityConfig{Type: protocol.SecurityType_NONE},
 		}
 		*tlsEnabled = true
+	case "grpc":
+		transportSettings = &grpc.Config{
+			ServiceName: *serviceName,
+		}
 	default:
 		return nil, newError("unsupported mode:", *mode)
 	}


### PR DESCRIPTION
Close: #247 
V2Ray recently add gRPC protocol, which seems to be harder to detect than WebSocket (over TLS), and can be forwarded by CDN.